### PR TITLE
Automatically publish MLflow AMI image and deploy it to EC2 through HashiCorp

### DIFF
--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Build docs
         run: make html
         working-directory: docs
-
       - name: Deploy docs to GitHub Pages
         if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   hashicorp:
-    name: Build & Publish MLflow UI & Tracking Server AMI images & Deploy the Images to EC2's
+    name: Publish MLflow AMI image and deploy it to EC2 through HashiCorp
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -1,0 +1,73 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: MLflow IaC Definition (HashiCorp)
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+env:
+  HASHICORP_PRODUCT_VERSION: "latest"
+
+jobs:
+  hashicorp:
+    name: Build & Publish MLflow UI & Tracking Server AMI images & Deploy the Images to EC2's
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: hashicorp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/master'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEPLOY_REGION }}
+
+      - name: Setup HashiCorp Packer
+        uses: hashicorp/setup-packer@main
+        with:
+          version: ${{ env.HASHICORP_PRODUCT_VERSION }}
+      - name: Initialize Packer configuration
+        run: packer init .
+        working-directory: hashicorp/images
+      - name: Validate Packer template
+        run: packer validate -var "aws_image_region=${{ secrets.AWS_IMAGE_REGION }}" .
+        working-directory: hashicorp/images
+      - name: Build and release AMI image
+        if: github.ref == 'refs/heads/master'
+        run: packer build -var "aws_image_region=${{ secrets.AWS_IMAGE_REGION }}" .
+        working-directory: hashicorp/images
+
+      - name: Setup HashiCorp Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.HASHICORP_PRODUCT_VERSION }}
+      - name: Initialize Terraform configuration
+        run: terraform init
+        working-directory: hashicorp/instances
+      - name: Validate Terraform template
+        run: terraform validate
+        working-directory: hashicorp/instances
+      - name: Create EC2 instance
+        if: github.ref == 'refs/heads/master'
+        run: terraform apply -auto-approve -var="aws_deploy_region=${{ secrets.AWS_DEPLOY_REGION }}"
+        working-directory: hashicorp/instances

--- a/docs/source/hashicorp.rst
+++ b/docs/source/hashicorp.rst
@@ -1,0 +1,64 @@
+MLflow AMI Image
+================
+
+A public MLflow AMI image is available at `AWS AMI <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html>`_ for
+anyone with an AWS account. The *AMI name* is "**jack20191124-mlflow**" and *Owner ID* is "**899075777617**". We
+could, for example, deploy an EC2 instance of this image using HashiCorp Terraform:
+
+.. code-block:: terraform
+
+  terraform {
+    required_providers {
+      aws = {
+        source  = "hashicorp/aws"
+        version = "~> 4.42.0"
+      }
+    }
+    required_version = ">= 0.14.5"
+  }
+
+  provider "aws" {
+    region = "us-east-1"
+  }
+
+  data "aws_ami" "latest-jack20191124-mlflow" {
+    most_recent = true
+    owners = ["899075777617"]
+
+    filter {
+      name   = "name"
+      values = ["jack20191124-mlflow"]
+    }
+
+    filter {
+      name   = "virtualization-type"
+      values = ["hvm"]
+    }
+  }
+
+  resource "aws_instance" "mlflow-tracking-server" {
+    ami = "${data.aws_ami.latest-jack20191124-mlflow.id}"
+    instance_type = "t2.micro"
+    tags = {
+      Name = "MLflow UI & Tracking Server"
+    }
+
+    user_data = <<-EOF
+      #!/bin/bash
+      mlflow server --host 0.0.0.0
+    EOF
+  }
+
+- Please do not forget to specify the ``AWS_ACCESS_KEY_ID`` & ``AWS_SECRET_ACCESS_KEY`` environment variables of the
+  `IAM user <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users.html>`_, because
+  `terraform needs to be authenticated <https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build>`_
+  to create EC2 instances on behalf of that user.
+- Note that the configuration above deploys the EC2 instance to East 1 region
+- When deployed, the EC2 instance name will be "MLflow UI & Tracking Server".
+- After EC2 is instantiated, we still need to manually attach
+  `security group <https://docs.aws.amazon.com/vpc/latest/userguide/security-groups.html>`_ to that instance. There is
+  a plan, though, to enable automatically attaching a pre-configured security group
+
+  - The security group must have TCP port 5000 open for its UI access
+
+The MLflow instance, after deployment, can be accessed at "http://<ec2-public-ip>:5000"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,5 +42,6 @@ Get started using the :ref:`quickstart` or by reading about the :ref:`key concep
     java_api/index
     rest-api
     docker
+    hashicorp
     community-model-flavors
 

--- a/hashicorp/images/aws-mlflow-base.pkr.hcl
+++ b/hashicorp/images/aws-mlflow-base.pkr.hcl
@@ -1,0 +1,54 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 0.0.2"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+source "amazon-ebs" "jack20191124-mlflow" {
+  ami_name = "jack20191124-mlflow"
+  force_deregister = "true"
+  force_delete_snapshot = "true"
+
+  ami_groups = ["all"]
+
+  instance_type = "t2.micro"
+  region = "${var.aws_image_region}"
+  source_ami_filter {
+    filters = {
+      name = "ubuntu/images/*ubuntu-*-20.04-amd64-server-*"
+      root-device-type = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners = ["099720109477"]
+  }
+  ssh_username = "ubuntu"
+}
+
+build {
+  name = "install-jack20191124-mlflow"
+  sources = [
+    "source.amazon-ebs.jack20191124-mlflow"
+  ]
+
+  provisioner "shell" {
+    script = "../scripts/setup.sh"
+  }
+}

--- a/hashicorp/images/variables.pkr.hcl
+++ b/hashicorp/images/variables.pkr.hcl
@@ -1,0 +1,4 @@
+variable "aws_image_region" {
+  type =  string
+  sensitive = true
+}

--- a/hashicorp/instances/main.tf
+++ b/hashicorp/instances/main.tf
@@ -1,0 +1,60 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "aws_deploy_region" {
+  type = string
+  description = "The EC2 region"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.42.0"
+    }
+  }
+  required_version = ">= 0.14.5"
+}
+
+provider "aws" {
+  region = var.aws_deploy_region
+}
+
+data "aws_ami" "latest-jack20191124-mlflow" {
+  most_recent = true
+  owners = ["899075777617"]
+
+  filter {
+    name   = "name"
+    values = ["jack20191124-mlflow"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "mlflow-tracking-server" {
+  ami = "${data.aws_ami.latest-jack20191124-mlflow.id}"
+  instance_type = "t2.micro"
+  tags = {
+    Name = "MLflow UI & Tracking Server"
+  }
+
+  user_data = <<-EOF
+    #!/bin/bash
+    mlflow server --host 0.0.0.0
+  EOF
+}

--- a/hashicorp/scripts/setup.sh
+++ b/hashicorp/scripts/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -x
+
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo apt update && sudo apt upgrade -y
+sudo apt install software-properties-common -y
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt install python3.8 -y
+sudo apt install python3-pip -y
+
+sudo pip3 install mlflow
+
+# Fix pip3 install mlflow 'ERROR: flask 2.3.2 has requirement click>=8.1.3, but you'll have click 7.0 which is incompatible.'
+sudo pip3 install click==8.1.3
+# And similar fixes
+sudo pip3 install zipp==3.1.0
+sudo pip3 install urllib3==1.26.7
+sudo pip3 install requests==2.26.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Each pull request against `master` branch runs MLflow AMI image (Packer) test and its deploy logic (Terraform) tests
- Each `master` branch commit run the tests above and, if successful, publish the image to AWS AMI registry and then deploy the images to EC2 instances automatically

  - The registry and EC2 locations are determined by the following environment variables in CI/CD:

    - **AWS_ACCESS_KEY_ID** ([AWS standard variable](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html))
    - **AWS_SECRET_ACCESS_KEY** ([AWS standard variable](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html))
    - **AWS_IMAGE_REGION** (NON-AWS: region where IAM image will be published to, e.g. `us-east-1`)
    - **AWS_DEPLOY_REGION** (NON-AWS: region where EC2 instance will be deployed to, e.g. `us-east-1`)

## Reference

- [Create a "Public" Amazon AMI](https://github.com/hashicorp/packer/issues/1762#issuecomment-68086756)
- [Unable to see mlflow ui at http://127.0.0.1:5000 when mlflow is running in docker container](https://github.com/mlflow/mlflow/issues/109#issuecomment-404146077)

## How is this patch tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask.
-->

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (describe details, including test results, below)

<!--
Please describe how you confirmed the proposed feature/bug-fix/change works here. For example, if you fixed an MLflow client API, you could attach the code that didn't work prior to the fix but works now, or if you added a new feature on MLflow UI, you could attach a video that demonstrates the feature.
-->

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly in the documentation preview.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
